### PR TITLE
Add a white buffer around carousel titles to avoid black on dark gray situations

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2324,6 +2324,7 @@ div.explanation {
 
   .carousel-caption .carousel-title {
     font-size: 44px;
+    text-shadow: -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff;
   }
 
   .qf-button a,


### PR DESCRIPTION
Look at the 'edit' part of the title.

Before:

<img width="451" height="520" alt="image" src="https://github.com/user-attachments/assets/e52c9bdd-c175-4881-8f57-b9de1ed78d8e" />

PR:

<img width="451" height="523" alt="image" src="https://github.com/user-attachments/assets/1fd65f7d-acd0-4308-90e2-722f46ba67cc" />
