### PR TITLE
Fix color of QFieldCloud link on dark theme, keep font weight bold when hovering/focusing on link

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -575,14 +575,19 @@ p {
   text-align: center;
 }
 
-.link-qfieldcloud {
+.link-qfieldcloud,
+[data-bs-theme='dark'] .link-qfieldcloud {
   color: var(--qfieldcloud-color);
   font-weight: bold;
 }
 
 .link-qfieldcloud:hover,
-.link-qfieldcloud:focus {
+.link-qfieldcloud:focus,
+[data-bs-theme='dark'] .link-qfieldcloud:hover,
+[data-bs-theme='dark'] .link-qfieldcloud:focus
+ {
   color: var(--qfieldcloud-color);
+  font-weight: bold;
 }
 
 .customer-logo--wide {


### PR DESCRIPTION
One more tiny fix:

<img width="531" height="601" alt="image" src="https://github.com/user-attachments/assets/24aed683-b064-465e-858e-07148e53917d" />

The QFieldCloud link isn't blue when toggling the dark theme on.