### PR TITLE
Discourse embedding doesn't support dark theme, let's make sure its outer container looks better on qfield.org/blog

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3779,7 +3779,7 @@ div.explanation {
 }
 
 [data-bs-theme='dark'] .blog-comments-section__embed {
-  background: rgba(47, 47, 47, 0.9);
+  background: rgba(255, 255, 255, 1.0);
   border-color: rgba(128, 204, 40, 0.28);
   box-shadow: 0 14px 34px rgba(0, 0, 0, 0.28);
 }


### PR DESCRIPTION
Before:

<img width="1875" height="432" alt="image" src="https://github.com/user-attachments/assets/b4a15d7f-6d21-4450-9d33-a0efafc48288" />

<img width="1875" height="305" alt="image" src="https://github.com/user-attachments/assets/22750fdd-2ec6-46c2-81fe-66423133f595" />

PR:

<img width="1875" height="432" alt="image" src="https://github.com/user-attachments/assets/592a3e00-efba-4222-bd43-6b14990b8940" />

<img width="1875" height="305" alt="image" src="https://github.com/user-attachments/assets/d09acf41-761c-4690-9e7b-9a862f4a77dc" />

