### PR TITLE
Update main.css to fix transition between dark and light mode

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3652,8 +3652,7 @@ div.explanation {
 }
 
 [data-bs-theme='dark'] .main-header,
-[data-bs-theme='dark'] #navbar,
-[data-bs-theme='dark'] #navbar .navbar-collapse {
+[data-bs-theme='dark'] #navbar {
   background-color: #262626;
 }
 


### PR DESCRIPTION
the transition between dark and light mode is very annoying: This middle part immediately becomes black, while the rest of the top bar beautifully transitions. The black part of the menu should also transition it's color smoothly. To fix that, I just remove it's explicit background so we use the transition from the rest of the top bar.

<img width="512" height="60" alt="image" src="https://github.com/user-attachments/assets/65f4e664-50e6-4334-97e7-f45e15049738" />
